### PR TITLE
README.md: Update link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KIProtect Documentation
 
-These files are used to build the documentation at https://kiprotect.com/docs.
+These files are used to build the documentation at https://heykodex.com/docs/.
 
 ## Setting up the environment
 


### PR DESCRIPTION
Hi,

I noticed that the current link points to a 404 page.
If you don't plan to redirect that URL, I think this should say https://heykodex.com/docs/.

Feel free to close this PR and make the change yourself, if you don't want commits from outside authors at this point. (I see no license on this repo.)

All the best for you and Kodex,
Christian